### PR TITLE
update lodash to deal with prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r7insight_node",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Logentries client for node; use with or without Winston or Bunyan.",
   "keywords": [
     "logentries",
@@ -46,7 +46,7 @@
     "babel-runtime": "6.6.1",
     "codependency": "0.1.4",
     "json-stringify-safe": "5.0.1",
-    "lodash": "4.17.11",
+    "lodash": "4.17.12",
     "semver": "5.1.0",
     "reconnect-core": "1.3.0"
   },


### PR DESCRIPTION
a run of 'npm audit' revealed that this package relies on explicit version of lodash that has not been patched. Incrementing patch number to address.