### PR TITLE
LOG-16581 Fix winston JSON logging

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "env": { "es6": true, "node": true },
   "extends": "rapid7/node",
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
   "rules": {
     "comma-dangle": 0,
     "prefer-rest-params": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r7insight_node",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r7insight_node",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Rapid7 Insight Platform client for node; use with or without Winston or Bunyan.",
   "keywords": [
     "logentries",

--- a/src/transport.js
+++ b/src/transport.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const Logger = require('./logger');
-const serializer = require('./serialize');
+const stringify = require('json-stringify-safe');
 
 /**
  * Generate the InsightTransport Winston Transport.  
@@ -98,7 +98,7 @@ function generateTransport(winston, winstonTransport) {
         });
       } else if (Object.keys(info).length > 2) {
         //  If we are not outputting to JSON and have metadata, we use the same format as Winston
-        const message = `${info.level}: ${info.message} ${serializer(this)(metadata)}`;
+        const message = `${info.level}: ${info.message} ${stringify(metadata)}`;
 
         this.logger.log(message);
       } else {

--- a/src/transport.js
+++ b/src/transport.js
@@ -76,7 +76,10 @@ function generateTransport(winston, winstonTransport) {
         const splat = meta[Symbol.for('splat')];
 
         if (splat && splat.length) {
-          return splat.reduce((result, current) => Object.assign(result, current), {});
+          return splat.reduce((result, current) => ({
+            ...result,
+            ...current
+          }), {});
         }
 
         return {};

--- a/src/transport.js
+++ b/src/transport.js
@@ -29,7 +29,6 @@ function generateTransport(winston, winstonTransport) {
     */
     constructor(opts) {
       super(opts);
-      this.json = opts.json || false;
 
       const transportOpts = _.clone(opts || {});
 
@@ -65,23 +64,16 @@ function generateTransport(winston, winstonTransport) {
      * @returns {void}
     */
     log(info) {
-      //  If we have specified to log in JSON format, then stringify
+      //  winston should handle parsing and give us a complete message that we should log without any magic
+      //  required on our side.
       //
-      //  Also, if the `info` object which is passed from winston has more
-      //  that 2 default keys (`message` and `level`), then that means that
-      //  the `log` function was called with more two than keys
-      //  (referred to as metadata), so in that scenario we stringify the
-      //  entire message since it is not obvious what format the user wants.
-      //  
-      //  log function, without being given a log (like below) will just log
-      //  the level, which in this case is our message.
-      if (this.json || Object.keys(info).length > 2) {
-        this.logger.log(stringify(info));
-      } else {
-        //  If we do get the default keys of `level` and `message` then we
-        //  can use the default format of `<level> <message>`
-        this.logger.log(info.level, info.message);
-      }
+      //  We do not serialize the string to JSON since our InsightLogger appends extra fields
+      //  e.g. timestamp to it. So we pass in an object and leave serialization up to the logger.
+      //
+      //  Here we don't specify the first argument of level since the winston `info` object
+      //  already contains it.
+      //  If we did then our InsightLogger would append an extra redundant `_level` key.
+      this.logger.log({...info});
     }
 
     /**

--- a/src/transport.js
+++ b/src/transport.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
-const stringify = require('json-stringify-safe');
 
 const Logger = require('./logger');
+const serializer = require('./serialize');
 
 /**
  * Generate the InsightTransport Winston Transport.  
@@ -29,6 +29,7 @@ function generateTransport(winston, winstonTransport) {
     */
     constructor(opts) {
       super(opts);
+      this.json = !!opts.json;
 
       const transportOpts = _.clone(opts || {});
 
@@ -64,16 +65,46 @@ function generateTransport(winston, winstonTransport) {
      * @returns {void}
     */
     log(info) {
-      //  winston should handle parsing and give us a complete message that we should log without any magic
-      //  required on our side.
-      //
-      //  We do not serialize the string to JSON since our InsightLogger appends extra fields
-      //  e.g. timestamp to it. So we pass in an object and leave serialization up to the logger.
-      //
-      //  Here we don't specify the first argument of level since the winston `info` object
-      //  already contains it.
-      //  If we did then our InsightLogger would append an extra redundant `_level` key.
-      this.logger.log({...info});
+      //  This function is required since Winston passes in metadata in a strange way.
+      //  Rather than giving us a complete object containing all metadata, it hides it away
+      //  in the splat attribute and passes in only the first piece of metadata
+      //  
+      //  This seems to be an existing issue faced by devs:
+      //  https://stackoverflow.com/a/60866937
+      const returnMetadata = (meta) => {
+        // You can format the splat yourself
+        const splat = meta[Symbol.for('splat')];
+
+        if (splat && splat.length) {
+          return splat.reduce((result, current) => Object.assign(result, current), {});
+        }
+
+        return {};
+      };
+
+      const metadata = returnMetadata(info);
+
+      if (this.json) {
+        //  If we are to output JSON, we create the full object containing level, message and metadata.
+        //
+        //  We don't serialize here but pass in an object since InsightLogger appends extra keys based on
+        //  configuration, e.g. timestamp before serializing to JSON
+        //
+        //  We also don't specify the first argument of `level` since the winston `info` contains it.
+        //  If we did provide it InsightLogger would append an extra redundant `_level` key.
+        this.logger.log({
+          ...info,
+          ...metadata,
+        });
+      } else if (Object.keys(info).length > 2) {
+        //  If we are not outputting to JSON and have metadata, we use the same format as Winston
+        const message = `${info.level}: ${info.message} ${serializer(this)(metadata)}`;
+
+        this.logger.log(message);
+      } else {
+        //  If we're not outputting JSON, nor have metadata, we produce a simple message
+        this.logger.log(info.level, info.message);
+      }
     }
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ tape('Custom levels with duplicate names throw.', function (t) {
 tape('Custom levels with conflicting names throw.', function (t) {
 
   function makeLogger(levels) {
-    new Logger({ token, levels: levels, region: 'eu' });
+    new Logger({ token, levels, region: 'eu' });
   }
 
   t.throws(makeLogger.bind(null, ['log']), 'own property');
@@ -671,7 +671,7 @@ tape('Winston supports string format logging', function (t) {
     messageReceived++;
 
     t.pass('winston log transmits');
-    t.equal(data, token + ' warn mysterious radiation\n', 'msg as expected');
+    t.equal(data, `${token} warn mysterious radiation\n`, 'msg as expected');
   });
 
   winston.warn('mysterious radiation');
@@ -854,7 +854,7 @@ tape("Winston supports json logging.", function (t) {
       level: "warn",
       message: "msg",
     };
-    t.equal(data, token + " " + JSON.stringify(expect) + '\n', 'json as expected');
+    t.equal(data, `${token} ${JSON.stringify(expect)}\n`, 'json as expected');
   });
 
   logger.warn("msg", { foo: "bar" });

--- a/test/test.js
+++ b/test/test.js
@@ -797,6 +797,40 @@ tape('Winston supports JSON format logging with multiple metadata', function (t)
   winston.error('test error message with error with metadata', { account_id: 'account_id' }, { hello_there: 'general kenobi' });
 });
 
+tape('Winston supports JSON format logging with timestamps', function (t) {
+  t.plan(4);
+  t.timeoutAfter(1000);
+
+  t.true(winston.transports.Insight,
+      'provisioned constructor automatically');
+
+  winston.remove(winston.transports.Insight);
+  t.doesNotThrow(function () {
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true, timestamp: true }));
+  }, 'transport can be added');
+
+  winston.remove(winston.transports.Console);
+
+  let messageReceived = 0;
+
+  mockTest((data) => {
+    //  We're only expecting one message, don't accept other messages
+    if (messageReceived == 1) return;
+    messageReceived++;
+
+    t.pass('winston log transmits');
+
+    //  Remove token
+    data = data.substring(token.length + 1);
+
+    //  Turn to object
+    data = JSON.parse(data);
+    t.assert(data.time);
+  });
+
+  winston.error('test error message with error with metadata');
+});
+
 tape("Winston supports json logging.", function (t) {
   t.plan(2);
   t.timeoutAfter(2000);

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ tape('Custom levels with duplicate names throw.', function (t) {
 tape('Custom levels with conflicting names throw.', function (t) {
 
   function makeLogger(levels) {
-    new Logger({ token: token, levels: levels, region: 'eu' });
+    new Logger({ token, levels: levels, region: 'eu' });
   }
 
   t.throws(makeLogger.bind(null, ['log']), 'own property');
@@ -146,7 +146,7 @@ tape('Logger does not forgive or forget.', function (t) {
   /* jshint newcap: false */
 
   t.throws(function () {
-    Logger({ token: token, region: 'eu' });
+    Logger({ token, region: 'eu' });
   }, 'missing new throws');
 
   t.end();
@@ -154,7 +154,7 @@ tape('Logger does not forgive or forget.', function (t) {
 
 tape('Logger allows custom log level methods at construction.', function (t) {
   const logger = new Logger({
-    token: token,
+    token,
     levels: ['tiny', 'small'],
     region: 'eu'
   });
@@ -175,15 +175,15 @@ tape('Logger allows specification of minLevel at construction', function (t) {
 
   const name = defaults.levels[3];
 
-  const logger1 = new Logger({ token: token, minLevel: name, region: 'eu' });
+  const logger1 = new Logger({ token, minLevel: name, region: 'eu' });
 
   t.equal(logger1.minLevel, 3, 'by name.');
 
-  const logger2 = new Logger({ token: token, minLevel: 3, region: 'eu' });
+  const logger2 = new Logger({ token, minLevel: 3, region: 'eu' });
 
   t.equal(logger2.minLevel, 3, 'by index (num)');
 
-  const logger3 = new Logger({ token: token, minLevel: '3', region: 'eu' });
+  const logger3 = new Logger({ token, minLevel: '3', region: 'eu' });
 
   t.equal(logger3.minLevel, 3, 'by index (str)');
 
@@ -198,7 +198,7 @@ tape('Error objects are serialized nicely.', function (t) {
   const err = new Error(msg);
   const log = { errs: [err] };
 
-  const logger1 = new Logger({ token: token, region: 'eu' });
+  const logger1 = new Logger({ token, region: 'eu' });
 
   t.equal(JSON.parse(logger1.serialize(err)).message, msg,
       'error object is serialized.');
@@ -209,7 +209,7 @@ tape('Error objects are serialized nicely.', function (t) {
   t.equal(JSON.parse(logger1.serialize(err)).stack, undefined,
       'by default, stack is not included.');
 
-  const logger2 = new Logger({ token: token, withStack: true, region: 'eu' });
+  const logger2 = new Logger({ token, withStack: true, region: 'eu' });
 
   t.true(JSON.parse(logger2.serialize(err)).stack,
       'withStack option causes its inclusion.');
@@ -223,7 +223,7 @@ tape('Arguments and regex patterns are serialized.', function (t) {
   })(1, 2, 3);
   const regObj = /abc/;
 
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   t.true(logger.serialize(argObj) === '[1,2,3]', 'arguments become arrays.');
 
@@ -243,7 +243,7 @@ tape('Custom value transformer is respected.', function (t) {
     err: new Error('not kittens :(')
   };
 
-  const logger = new Logger({ token: token, replacer: alwaysKittens, region: 'eu' });
+  const logger = new Logger({ token, replacer: alwaysKittens, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(log));
 
@@ -264,7 +264,7 @@ tape('Circular references don’t make the sad times.', function (t) {
   const consciousness = {};
   consciousness.iAm = consciousness;
 
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(consciousness));
 
@@ -284,7 +284,7 @@ tape('Serialize objects that inherit from non-Object objects fine', function (t)
 
   newObj.prop = 1;
 
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(newObj));
 
@@ -300,7 +300,7 @@ tape('Object.create(null) objects don’t destroy everything.', function (t) {
 
   nullObj.prop = 1;
 
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(nullObj));
 
@@ -331,14 +331,14 @@ tape('Flattening options work.', function (t) {
   }
 
   const logger1 = new Logger({
-    token: token,
+    token,
     flatten: true,
     flattenArrays: false,
     region: 'eu'
   });
 
   const logger2 = new Logger({
-    token: token,
+    token,
     flatten: true,
     replacer: replacer,
     region: 'eu'
@@ -539,7 +539,7 @@ tape('Directly logged error objects survive.', function (t) {
 
   const message = 'warp breach imminent';
   const error = new Error(message);
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   logger.on('error', function (err) {
     t.comment(err.stack);
@@ -558,7 +558,7 @@ tape('Invalid calls to log methods emit error.', function (t) {
   t.plan(2);
   t.timeoutAfter(500);
 
-  const logger1 = new Logger({ token: token, region: 'eu' });
+  const logger1 = new Logger({ token, region: 'eu' });
 
   logger1.on('error', function () {
     t.pass('no arguments');
@@ -566,7 +566,7 @@ tape('Invalid calls to log methods emit error.', function (t) {
 
   logger1.log(3);
 
-  const logger2 = new Logger({ token: token, region: 'eu' });
+  const logger2 = new Logger({ token, region: 'eu' });
 
   logger2.on('error', function () {
     t.pass('empty array');
@@ -579,7 +579,7 @@ tape('Socket gets re-opened as needed.', function (t) {
   t.plan(1);
   t.timeoutAfter(3000);
 
-  const logger = new Logger({ token: token, region: 'eu' });
+  const logger = new Logger({ token, region: 'eu' });
 
   mockTest(function (data) {
 
@@ -605,7 +605,7 @@ tape('Socket is not closed after inactivity timeout when buffer is not empty.', 
   t.timeoutAfter(1000);
   const lvl = defaults.levels[3];
   const tkn = token;
-  const logger = new Logger({ token: token, inactivityTimeout: 300, region: 'eu' });
+  const logger = new Logger({ token, inactivityTimeout: 300, region: 'eu' });
 
   const mock = mitm();
 
@@ -658,7 +658,7 @@ tape('Winston supports string format logging', function (t) {
       'provisioned constructor automatically');
 
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu' }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -686,7 +686,7 @@ tape('Winston supports string format logging with metadata', function (t) {
 
   winston.remove(winston.transports.Insight);
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu' }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -716,7 +716,7 @@ tape('Winston supports string format logging with multiple metadata', function (
 
   winston.remove(winston.transports.Insight);
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu' }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -746,7 +746,7 @@ tape('Winston supports JSON format logging with metadata', function (t) {
 
   winston.remove(winston.transports.Insight);
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu', json: true }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -776,7 +776,7 @@ tape('Winston supports JSON format logging with multiple metadata', function (t)
 
   winston.remove(winston.transports.Insight);
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu', json: true }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -806,7 +806,7 @@ tape('Winston supports JSON format logging with timestamps', function (t) {
 
   winston.remove(winston.transports.Insight);
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true, timestamp: true }));
+    winston.add(new winston.transports.Insight({ token, region: 'eu', json: true, timestamp: true }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
@@ -837,7 +837,7 @@ tape("Winston supports json logging.", function (t) {
 
   const logger = winston.createLogger({
     transports: [
-      new winston.transports.Insight({ token: token, region: 'eu', json: true }),
+      new winston.transports.Insight({ token, region: 'eu', json: true }),
     ]
   });
 
@@ -867,7 +867,7 @@ tape("Winston supports json logging.", function (t) {
 tape('Bunyan integration is provided.', function (t) {
   t.plan(9);
 
-  const streamDef = Logger.bunyanStream({ token: token, minLevel: 3, region: 'eu' });
+  const streamDef = Logger.bunyanStream({ token, minLevel: 3, region: 'eu' });
 
   t.true(streamDef, 'bunyan stream definition created');
 
@@ -904,7 +904,7 @@ tape('Bunyan integration is provided.', function (t) {
 tape('Bunyan integration respects region option.', function (t) {
   t.plan(2);
 
-  const streamDef = Logger.bunyanStream({ token: token, minLevel: 3, region: 'craggy_island' });
+  const streamDef = Logger.bunyanStream({ token, minLevel: 3, region: 'craggy_island' });
 
   t.equal(streamDef.stream._logger._host, 'craggy_island.data.logs.insight.rapid7.com')
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ const Logger = require('../src/index.js');
 const RingBuffer = require('../src/ringBuffer.js');
 
 //  Fake token
-const x = '00000000-0000-0000-0000-000000000000';
+const token = '00000000-0000-0000-0000-000000000000';
 
 // CUSTOM LEVEL NAMES
 
@@ -111,7 +111,7 @@ tape('Custom levels with duplicate names throw.', function (t) {
 tape('Custom levels with conflicting names throw.', function (t) {
 
   function makeLogger(levels) {
-    new Logger({ token: x, levels: levels, region: 'eu' });
+    new Logger({ token: token, levels: levels, region: 'eu' });
   }
 
   t.throws(makeLogger.bind(null, ['log']), 'own property');
@@ -146,7 +146,7 @@ tape('Logger does not forgive or forget.', function (t) {
   /* jshint newcap: false */
 
   t.throws(function () {
-    Logger({ token: x, region: 'eu' });
+    Logger({ token: token, region: 'eu' });
   }, 'missing new throws');
 
   t.end();
@@ -154,7 +154,7 @@ tape('Logger does not forgive or forget.', function (t) {
 
 tape('Logger allows custom log level methods at construction.', function (t) {
   const logger = new Logger({
-    token: x,
+    token: token,
     levels: ['tiny', 'small'],
     region: 'eu'
   });
@@ -175,15 +175,15 @@ tape('Logger allows specification of minLevel at construction', function (t) {
 
   const name = defaults.levels[3];
 
-  const logger1 = new Logger({ token: x, minLevel: name, region: 'eu' });
+  const logger1 = new Logger({ token: token, minLevel: name, region: 'eu' });
 
   t.equal(logger1.minLevel, 3, 'by name.');
 
-  const logger2 = new Logger({ token: x, minLevel: 3, region: 'eu' });
+  const logger2 = new Logger({ token: token, minLevel: 3, region: 'eu' });
 
   t.equal(logger2.minLevel, 3, 'by index (num)');
 
-  const logger3 = new Logger({ token: x, minLevel: '3', region: 'eu' });
+  const logger3 = new Logger({ token: token, minLevel: '3', region: 'eu' });
 
   t.equal(logger3.minLevel, 3, 'by index (str)');
 
@@ -198,7 +198,7 @@ tape('Error objects are serialized nicely.', function (t) {
   const err = new Error(msg);
   const log = { errs: [err] };
 
-  const logger1 = new Logger({ token: x, region: 'eu' });
+  const logger1 = new Logger({ token: token, region: 'eu' });
 
   t.equal(JSON.parse(logger1.serialize(err)).message, msg,
       'error object is serialized.');
@@ -209,7 +209,7 @@ tape('Error objects are serialized nicely.', function (t) {
   t.equal(JSON.parse(logger1.serialize(err)).stack, undefined,
       'by default, stack is not included.');
 
-  const logger2 = new Logger({ token: x, withStack: true, region: 'eu' });
+  const logger2 = new Logger({ token: token, withStack: true, region: 'eu' });
 
   t.true(JSON.parse(logger2.serialize(err)).stack,
       'withStack option causes its inclusion.');
@@ -223,7 +223,7 @@ tape('Arguments and regex patterns are serialized.', function (t) {
   })(1, 2, 3);
   const regObj = /abc/;
 
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   t.true(logger.serialize(argObj) === '[1,2,3]', 'arguments become arrays.');
 
@@ -243,7 +243,7 @@ tape('Custom value transformer is respected.', function (t) {
     err: new Error('not kittens :(')
   };
 
-  const logger = new Logger({ token: x, replacer: alwaysKittens, region: 'eu' });
+  const logger = new Logger({ token: token, replacer: alwaysKittens, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(log));
 
@@ -264,7 +264,7 @@ tape('Circular references don’t make the sad times.', function (t) {
   const consciousness = {};
   consciousness.iAm = consciousness;
 
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(consciousness));
 
@@ -284,7 +284,7 @@ tape('Serialize objects that inherit from non-Object objects fine', function (t)
 
   newObj.prop = 1;
 
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(newObj));
 
@@ -300,7 +300,7 @@ tape('Object.create(null) objects don’t destroy everything.', function (t) {
 
   nullObj.prop = 1;
 
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   const res = JSON.parse(logger.serialize(nullObj));
 
@@ -331,14 +331,14 @@ tape('Flattening options work.', function (t) {
   }
 
   const logger1 = new Logger({
-    token: x,
+    token: token,
     flatten: true,
     flattenArrays: false,
     region: 'eu'
   });
 
   const logger2 = new Logger({
-    token: x,
+    token: token,
     flatten: true,
     replacer: replacer,
     region: 'eu'
@@ -394,7 +394,7 @@ tape('Data is sent over standard connection.', function (t) {
 
   const lvl = defaults.levels[3];
   const msg = 'test';
-  const tkn = x;
+  const tkn = token;
 
   const mock = mitm();
 
@@ -426,7 +426,7 @@ tape('Data is sent over secure connection.', function (t) {
 
   const lvl = defaults.levels[3];
   const msg = 'test';
-  const tkn = x;
+  const tkn = token;
 
   const mock = mitm();
 
@@ -459,7 +459,7 @@ tape('Log methods can send multiple entries.', function (t) {
   t.timeoutAfter(4000);
 
   const lvl = defaults.levels[3];
-  const tkn = x;
+  const tkn = token;
   const logger = new Logger({ token: tkn, region: 'eu' });
   let count = 0;
 
@@ -484,9 +484,9 @@ tape('Non-JSON logs may carry timestamp.', function (t) {
   });
 
   const lvl = defaults.levels[3];
-  const tkn = x;
+  const tkn = token;
   const pattern = new RegExp(
-      '^' + x +
+      '^' + token +
       ' \\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d.\\d{3}Z \\w+ test\\n$'
   );
 
@@ -524,7 +524,7 @@ tape('JSON logs match expected pattern.', function (t) {
   });
 
   const lvl = defaults.levels[3];
-  const tkn = x;
+  const tkn = token;
   const timestampPattern = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d.\d{3}Z$/;
 
   const logger = new Logger({ token: tkn, timestamp: true, region: 'eu' });
@@ -539,7 +539,7 @@ tape('Directly logged error objects survive.', function (t) {
 
   const message = 'warp breach imminent';
   const error = new Error(message);
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   logger.on('error', function (err) {
     t.comment(err.stack);
@@ -558,7 +558,7 @@ tape('Invalid calls to log methods emit error.', function (t) {
   t.plan(2);
   t.timeoutAfter(500);
 
-  const logger1 = new Logger({ token: x, region: 'eu' });
+  const logger1 = new Logger({ token: token, region: 'eu' });
 
   logger1.on('error', function () {
     t.pass('no arguments');
@@ -566,7 +566,7 @@ tape('Invalid calls to log methods emit error.', function (t) {
 
   logger1.log(3);
 
-  const logger2 = new Logger({ token: x, region: 'eu' });
+  const logger2 = new Logger({ token: token, region: 'eu' });
 
   logger2.on('error', function () {
     t.pass('empty array');
@@ -579,7 +579,7 @@ tape('Socket gets re-opened as needed.', function (t) {
   t.plan(1);
   t.timeoutAfter(3000);
 
-  const logger = new Logger({ token: x, region: 'eu' });
+  const logger = new Logger({ token: token, region: 'eu' });
 
   mockTest(function (data) {
 
@@ -604,8 +604,8 @@ tape('Socket is not closed after inactivity timeout when buffer is not empty.', 
   t.plan(3);
   t.timeoutAfter(1000);
   const lvl = defaults.levels[3];
-  const tkn = x;
-  const logger = new Logger({ token: x, inactivityTimeout: 300, region: 'eu' });
+  const tkn = token;
+  const logger = new Logger({ token: token, inactivityTimeout: 300, region: 'eu' });
 
   const mock = mitm();
 
@@ -650,7 +650,7 @@ tape('RingBuffer buffers and shifts when it is full', function (t) {
 
 // WINSTON TRANSPORT
 
-tape('Winston integration is provided.', function (t) {
+tape('Winston supports string format logging', function (t) {
   t.plan(4);
   t.timeoutAfter(1000);
 
@@ -658,17 +658,143 @@ tape('Winston integration is provided.', function (t) {
       'provisioned constructor automatically');
 
   t.doesNotThrow(function () {
-    winston.add(new winston.transports.Insight({ token: x, region: 'eu' }));
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
   }, 'transport can be added');
 
   winston.remove(winston.transports.Console);
 
+  let messageReceived = 0;
+
   mockTest((data) => {
+    //  We're only expecting one message
+    if (messageReceived == 1) return;
+    messageReceived++;
+
     t.pass('winston log transmits');
-    t.equal(data, x + ' warn mysterious radiation\n', 'msg as expected');
+    t.equal(data, token + ' warn mysterious radiation\n', 'msg as expected');
   });
 
   winston.warn('mysterious radiation');
+});
+
+tape('Winston supports string format logging with metadata', function (t) {
+  t.plan(4);
+  t.timeoutAfter(1000);
+
+  t.true(winston.transports.Insight,
+      'provisioned constructor automatically');
+
+  winston.remove(winston.transports.Insight);
+  t.doesNotThrow(function () {
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
+  }, 'transport can be added');
+
+  winston.remove(winston.transports.Console);
+
+  let messageReceived = 0;
+
+  mockTest((data) => {
+    //  We're only expecting one message
+    if (messageReceived == 1) return;
+    messageReceived++;
+
+    t.pass('winston log transmits');
+    const expectedMessage = `${token} error: test error message {"account_id":"account_id"}\n`;
+
+    t.equal(data, expectedMessage, 'msg as expected');
+  });
+
+  winston.error('test error message', { account_id: 'account_id' });
+});
+
+tape('Winston supports string format logging with multiple metadata', function (t) {
+  t.plan(4);
+  t.timeoutAfter(1000);
+
+  t.true(winston.transports.Insight,
+      'provisioned constructor automatically');
+
+  winston.remove(winston.transports.Insight);
+  t.doesNotThrow(function () {
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu' }));
+  }, 'transport can be added');
+
+  winston.remove(winston.transports.Console);
+
+  let messageReceived = 0;
+
+  mockTest((data) => {
+    //  We're only expecting one message
+    if (messageReceived == 1) return;
+    messageReceived++;
+
+    t.pass('winston log transmits');
+    const expectedMessage = `${token} error: test error message with error with metadata {"account_id":"account_id","hello_there":"general kenobi"}\n`;
+
+    t.equal(data, expectedMessage, 'msg as expected');
+  });
+
+  winston.error('test error message with error with metadata', { account_id: 'account_id' }, { hello_there: 'general kenobi' });
+});
+
+tape('Winston supports JSON format logging with metadata', function (t) {
+  t.plan(4);
+  t.timeoutAfter(1000);
+
+  t.true(winston.transports.Insight,
+      'provisioned constructor automatically');
+
+  winston.remove(winston.transports.Insight);
+  t.doesNotThrow(function () {
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true }));
+  }, 'transport can be added');
+
+  winston.remove(winston.transports.Console);
+
+  let messageReceived = 0;
+
+  mockTest((data) => {
+    //  We're only expecting one message, don't accept other messages
+    if (messageReceived == 1) return;
+    messageReceived++;
+
+    t.pass('winston log transmits');
+    const expectedMessage = `${token} {"account_id":"account_id","level":"error","message":"test error message"}\n`;
+
+    t.equal(data, expectedMessage, 'msg as expected');
+  });
+
+  winston.error('test error message', { account_id: 'account_id' });
+});
+
+tape('Winston supports JSON format logging with multiple metadata', function (t) {
+  t.plan(4);
+  t.timeoutAfter(1000);
+
+  t.true(winston.transports.Insight,
+      'provisioned constructor automatically');
+
+  winston.remove(winston.transports.Insight);
+  t.doesNotThrow(function () {
+    winston.add(new winston.transports.Insight({ token: token, region: 'eu', json: true }));
+  }, 'transport can be added');
+
+  winston.remove(winston.transports.Console);
+
+  let messageReceived = 0;
+
+  mockTest((data) => {
+    //  We're only expecting one message, don't accept other messages
+    if (messageReceived == 1) return;
+    messageReceived++;
+
+    t.pass('winston log transmits');
+    const expectedMessage = `${token} {"account_id":"account_id","level":"error","message":"test error message with error with metadata","hello_there":"general kenobi"}\n`;
+
+    t.equal(data, expectedMessage, 'msg as expected');
+  });
+
+  winston.error('test error message with error with metadata', { account_id: 'account_id' }, { hello_there: 'general kenobi' });
 });
 
 tape("Winston supports json logging.", function (t) {
@@ -677,19 +803,24 @@ tape("Winston supports json logging.", function (t) {
 
   const logger = winston.createLogger({
     transports: [
-      new winston.transports.Insight({ token: x, region: 'eu' }),
+      new winston.transports.Insight({ token: token, region: 'eu', json: true }),
     ]
   });
 
+  let messageReceived = 0;
 
   mockTest(function (data) {
+    //  We're only expecting one message
+    if (messageReceived == 1) return;
+    messageReceived++;
+
     t.pass("winston logs in json format");
     const expect = {
       foo: "bar",
       level: "warn",
       message: "msg",
     };
-    t.equal(data, x + " " + JSON.stringify(expect) + '\n', 'json as expected');
+    t.equal(data, token + " " + JSON.stringify(expect) + '\n', 'json as expected');
   });
 
   logger.warn("msg", { foo: "bar" });
@@ -702,7 +833,7 @@ tape("Winston supports json logging.", function (t) {
 tape('Bunyan integration is provided.', function (t) {
   t.plan(9);
 
-  const streamDef = Logger.bunyanStream({ token: x, minLevel: 3, region: 'eu' });
+  const streamDef = Logger.bunyanStream({ token: token, minLevel: 3, region: 'eu' });
 
   t.true(streamDef, 'bunyan stream definition created');
 
@@ -739,7 +870,7 @@ tape('Bunyan integration is provided.', function (t) {
 tape('Bunyan integration respects region option.', function (t) {
   t.plan(2);
 
-  const streamDef = Logger.bunyanStream({ token: x, minLevel: 3, region: 'craggy_island' });
+  const streamDef = Logger.bunyanStream({ token: token, minLevel: 3, region: 'craggy_island' });
 
   t.equal(streamDef.stream._logger._host, 'craggy_island.data.logs.insight.rapid7.com')
 


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
The issues:
- Before this fix, if we had winston metadata (basically extra logline attributes), we just stringified the entire message and passed it to the InsightLogger
  * Main problem was that if we had JSON and timestamps enabled, since we passed in a string to InsightLogger, we just prepended that to the string whereas it should've been an attribute in the logline
```json
before:
2021-04-04 04:04:04 { "message": "..." }
after:
{ "time": "2021-04-04 04:04:04", "message": "..." }
```

Added more code to bring the InsightLogger messages exactly inline with the winston format.

Current behaviour
- If JSON: extract all metadata into one object
- If not JSON but metadata: use same format as winston
- Else: no metadata, just log the message normally

Bumping major since this does affect loglines in Winston.

## Testing
<!-- Describe how this change was tested -->