### PR TITLE
Add withHostname option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ accessors, though, and invalid values will be ignored.
    or add the same as a property (if objects). Default: `false`.
  - **withLevel**: Will prepend (string) or add property (object) indicating the
    log level. Default: `true`.
+ - **withHostname**: Will prepend(string) or add property (object) indicating the 
+   hostname from which the log was sent. Default: `false`.
  - **withStack**: If an object is or contains an `Error` object, setting this to
    `true` will cause the stack trace to be included. Default: `false.`
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,5 @@
 const net = require('net');
+const os = require('os');
 const reconnectCore = require('reconnect-core');
 const tls = require('tls');
 const urlUtil = require('url');
@@ -114,6 +115,7 @@ class Logger extends Writable {
     this.flattenArrays = 'flattenArrays' in opts ? opts.flattenArrays : opts.flatten;
     this.console = opts.console;
     this.withLevel = 'withLevel' in opts ? opts.withLevel : true;
+    this.withHostname = opts.withHostname;
     this.withStack = opts.withStack;
     this.timestamp = opts.timestamp || false;
 
@@ -293,6 +295,7 @@ class Logger extends Writable {
     if (_.isObject(modifiedLog)) {
       let safeTime;
       let safeLevel;
+      let safeHost;
 
       if (this.timestamp) {
         safeTime = getSafeProp(modifiedLog, 'time');
@@ -303,6 +306,12 @@ class Logger extends Writable {
       if (this.withLevel && lvlName) {
         safeLevel = getSafeProp(modifiedLog, 'level');
         modifiedLog[safeLevel] = lvlName;
+      }
+
+      //  Set level if present
+      if (this.withHostname) {
+        safeHost = getSafeProp(modifiedLog, 'host');
+        modifiedLog[safeHost] = os.hostname();
       }
 
       modifiedLog = this._serialize(modifiedLog);
@@ -334,6 +343,10 @@ class Logger extends Writable {
 
       if (this.withLevel && lvlName) {
         modifiedLog.unshift(lvlName);
+      }
+
+      if (this.withHostname) {
+        modifiedLog.unshift(os.hostname());
       }
 
       if (this.timestamp) {
@@ -665,6 +678,14 @@ class Logger extends Writable {
 
   set withLevel(val) {
     this._withLevel = !!val;
+  }
+
+  get withHostname() {
+    return this._withHostname;
+  }
+
+  set withHostname(val) {
+    this._withHostname = !!val;
   }
 
   get withStack() {

--- a/src/logger.js
+++ b/src/logger.js
@@ -295,7 +295,7 @@ class Logger extends Writable {
     if (_.isObject(modifiedLog)) {
       let safeTime;
       let safeLevel;
-      let safeHost;
+      let safeHostname;
 
       if (this.timestamp) {
         safeTime = getSafeProp(modifiedLog, 'time');
@@ -310,8 +310,8 @@ class Logger extends Writable {
 
       //  Set level if present
       if (this.withHostname) {
-        safeHost = getSafeProp(modifiedLog, 'host');
-        modifiedLog[safeHost] = os.hostname();
+        safeHostname = getSafeProp(modifiedLog, 'hostname');
+        modifiedLog[safeHostname] = os.hostname();
       }
 
       modifiedLog = this._serialize(modifiedLog);

--- a/test/test.js
+++ b/test/test.js
@@ -521,8 +521,7 @@ tape('Non-JSON logs may carry Hostname.', function (t) {
   const os = require('os');
   const lvl = defaults.levels[3];
   const tkn = token;
-  const pattern = new RegExp('^' + token +' ' + os.hostname() + ' \\w+ test\\n$'
-  );
+  const pattern = new RegExp(`^${token} ${os.hostname()} \\w+ test\\n$`);
 
   const logger = new Logger({ token: tkn, withHostname: true, region: 'eu' });
 
@@ -536,7 +535,7 @@ tape('JSON logs may carry Hostname.', function (t) {
 
   mockTest(function (data) {
     const log = JSON.parse(data.substr(37));
-    t.true(log.host, 'has property');
+    t.equals(os.hostname(), log.hostname);
   });
   const os = require('os');
   const lvl = defaults.levels[3];


### PR DESCRIPTION
## Description
I need option withHostname in order to distinguish which node of application fired the log. I've copied and adjusted the code from le_node repository 

## Testing
Set `withHostname: true` option and add some logs. In log view you should see the host name at the begging of string or as extra property for json
