### PR TITLE
Fix `minLevel` option when using Winston

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ logger.log(2, 'my msg');
 ```
 
 It’s also possible to forgo log levels altogether. Just call `log` with a single
-argument and it will be interpretted as the log entry. When used this way, the
+argument and it will be interpreted as the log entry. When used this way, the
 `minLevel` setting is ignored.
 
 ## Events

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ accessors, though, and invalid values will be ignored.
    methods. More details on this below.
  - **minLevel**: The minimum level to actually record logs at. String or Number.
    Defaults to 0.
+ - **takeLevelFromLog**: If truthy, will take log message level from message. Default: `false`.  
+   E.g. if `true`:
+   ```javascript
+   // Rather than call different functions based on level:
+   logger.warn({message: 'hello'});
+   // You can call the same function with different levels within object:
+   logger.log({level: 'warn', message: 'hello'});
+   ```
  - **bufferSize**: The maximum number of log entries that may be queued in the 
    internal ring buffer for sending at a given moment. Default: `16192`.
  - **secure:** If truthy, uses a TLS connection. Default: `true`.

--- a/src/logger.js
+++ b/src/logger.js
@@ -111,6 +111,7 @@ class Logger extends Writable {
     this.secure = opts.secure === undefined ? defaults.secure : opts.secure;
     this.debugEnabled = opts.debug === undefined ? defaults.debug : opts.debug;
     this.json = !!opts.json;
+    this.takeLevelFromLog = !!opts.takeLevelFromLog;
     this.flatten = opts.flatten;
     this.flattenArrays = 'flattenArrays' in opts ? opts.flattenArrays : opts.flatten;
     this.console = opts.console;
@@ -251,11 +252,16 @@ class Logger extends Writable {
   log(lvl, log) {
     let modifiedLevel = lvl;
     let modifiedLog = log;
-    // Log is optional and not present, so we set the Log = Log Level
 
+    // If function is called without second argument, with just a message:
+    //  logger.log('oops');
+    //
+    //  Then we set the log level to null if we shouldn't take the level from the log,
+    //  since it doesn't exist.
+    //  We then place the message in the right variable.
     if (modifiedLog === undefined) {
       modifiedLog = modifiedLevel;
-      modifiedLevel = null;
+      modifiedLevel = this.takeLevelFromLog ? modifiedLog.level : null;
     }
 
     let lvlName;

--- a/test/test.js
+++ b/test/test.js
@@ -649,7 +649,79 @@ tape('Socket gets re-opened as needed.', function (t) {
       logger.log(3, 'qwerty');
     }, 500);
   }, 500);
+});
 
+
+tape('Logger minLevel option is supported and works', function (t) {
+  t.plan(1);
+  t.timeoutAfter(1000);
+
+  const logger = new Logger({
+    token,
+    region: 'eu',
+    minLevel: 'info',
+  });
+
+  mockTest(_ => {
+    t.fail('Data should not be sent with lower logger level.');
+  });
+
+  logger.debug('asd');
+  logger.log('debug', 'asd');
+  logger['debug']('asd');
+
+  t.pass('Test finished');
+});
+
+tape('Winston JSON logger minLevel option is supported and works', function (t) {
+  t.plan(1);
+  t.timeoutAfter(1000);
+
+  const logger = winston.createLogger({
+    transports: [
+      new winston.transports.Insight({
+        token,
+        region: 'eu',
+        minLevel: 'info',
+        json: true,
+      }),
+    ]
+  });
+
+  mockTest(_ => {
+    t.fail('Data should not be sent with lower logger level.');
+  });
+
+  logger.debug('asd');
+  logger.log('debug', 'asd');
+  logger['debug']('asd');
+
+  t.pass('Test finished');
+});
+
+tape('Winston String logger minLevel option is supported and works', function (t) {
+  t.plan(1);
+  t.timeoutAfter(1000);
+
+  const logger = winston.createLogger({
+    transports: [
+      new winston.transports.Insight({
+        token,
+        region: 'eu',
+        minLevel: 'info',
+      }),
+    ]
+  });
+
+  mockTest(_ => {
+    t.fail('Data should not be sent with lower logger level.');
+  });
+
+  logger.debug('asd');
+  logger.log('debug', 'asd');
+  logger['debug']('asd');
+
+  t.pass('Test finished');
 });
 
 tape('Socket is not closed after inactivity timeout when buffer is not empty.', function (t) {

--- a/test/test.js
+++ b/test/test.js
@@ -651,6 +651,48 @@ tape('Socket gets re-opened as needed.', function (t) {
   }, 500);
 });
 
+tape('Logger takeLevelFromLog option skips low log level messages', function (t) {
+  t.plan(1);
+  t.timeoutAfter(1000);
+
+  const logger = new Logger({
+    token,
+    region: 'eu',
+    minLevel: 'emerg',
+    takeLevelFromLog: true,
+  });
+
+  mockTest(_ => {
+    t.fail(`Log level is too low and message shouldn't be logged.`);
+  });
+
+  logger.log({level: 'warning', msg: 'ello'});
+  logger.log({level: 'alert', msg: 'ello'});
+  logger.log({level: 'crit', msg: 'ello'});
+  logger.log({level: 'err', msg: 'ello'});
+
+  t.pass('Test finished');
+});
+
+tape('Logger takeLevelFromLog option logs correct level log messages', function (t) {
+  t.plan(3);
+  t.timeoutAfter(1000);
+
+  const logger = new Logger({
+    token,
+    region: 'eu',
+    minLevel: 'crit',
+    takeLevelFromLog: true,
+  });
+
+  mockTest(_ => {
+    t.pass(`Message logged.`);
+  });
+
+  logger.log({level: 'crit', msg: 'ello'});
+  logger.log({level: 'alert', msg: 'ello'});
+  logger.log({level: 'emerg', msg: 'ello'});
+});
 
 tape('Logger minLevel option is supported and works', function (t) {
   t.plan(1);
@@ -695,6 +737,7 @@ tape('Winston JSON logger minLevel option is supported and works', function (t) 
   logger.debug('asd');
   logger.log('debug', 'asd');
   logger['debug']('asd');
+  logger.log({level: 'debug', message: 'msg'});
 
   t.pass('Test finished');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -694,6 +694,40 @@ tape('Logger takeLevelFromLog option logs correct level log messages', function 
   logger.log({level: 'emerg', msg: 'ello'});
 });
 
+tape('Logger takeLevelFromLog option logs correct level log messages with custom levels', function (t) {
+  t.plan(1);
+  t.timeoutAfter(1000);
+
+  const levels = {
+    foo: 0,
+    bar: 1,
+    baz: 2,
+    foobar: 3
+  };
+
+  const logger = new Logger({
+    token,
+    levels,
+    region: 'eu',
+    minLevel: 'foobar',
+    takeLevelFromLog: true,
+  });
+
+  mockTest(_ => {
+    t.pass(`Message logged.`);
+  });
+
+  logger.foo('asd');
+  logger.bar('asd');
+  logger.baz('asd');
+
+  logger.log({level: 'foo', msg: 'asd'});
+  logger.log({level: 'bar', msg: 'asd'});
+  logger.log({level: 'baz', msg: 'asd'});
+  //  only this call should be logged
+  logger.log({level: 'foobar', msg: 'asd'});
+});
+
 tape('Logger minLevel option is supported and works', function (t) {
   t.plan(1);
   t.timeoutAfter(1000);


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
TL;DR:
- Winston sets it's own logger levels after we create the Transport, therefore we need to make sure minLevel is also updated.
What happened was these were our levels:
```javascript
const levels = [
  'debug',
  'info',
  'notice',
  'warning',
  'err',
  'crit',
  'alert',
  'emerg'
];
```

And these were winstons:
```javascript
{
	  silly:0
	  debug:1
	  verbose:2
	  http:3
	  info:4
	  warn:5
	  error:6
}
```

So our `info` level is the equivalent of `debug` in winston.
Therefore with `info` minLevel, we were logging winston debug logs.

Issue:
https://github.com/rapid7/r7insight_node/issues/29

## Testing
<!-- Describe how this change was tested -->